### PR TITLE
Fix input jar loop returning on dir

### DIFF
--- a/src/main/java/net/minecraftforge/fart/internal/RenamerImpl.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RenamerImpl.java
@@ -99,7 +99,7 @@ class RenamerImpl implements Renamer {
             for (Enumeration<? extends ZipEntry> entries = in.entries(); entries.hasMoreElements();) {
                 final ZipEntry e = entries.nextElement();
                 if (e.isDirectory())
-                    return;
+                    continue;
                 String name = e.getName();
                 byte[] data = Util.toByteArray(in.getInputStream(e));
 


### PR DESCRIPTION
Before this change, RenamerImpl would simply stop iterating files in a jar if it encountered a directory (which would usually be the very first entry)