### PR TITLE
Add a new option to strip final from parameters

### DIFF
--- a/src/main/java/net/neoforged/art/Main.java
+++ b/src/main/java/net/neoforged/art/Main.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 
-package net.minecraftforge.fart;
+package net.neoforged.art;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -36,6 +36,7 @@ public class Main {
         OptionSpec<File> logO    = parser.accepts("log",    "File to log data to, optional, defaults to System.out").withRequiredArg().ofType(File.class);
         OptionSpec<File> libO    = parser.acceptsAll(Arrays.asList("lib", "e"), "Additional library to use for inheritance").withRequiredArg().ofType(File.class);
         OptionSpec<Void> fixAnnO = parser.accepts("ann-fix", "Fixes misaligned parameter annotations caused by Proguard");
+        OptionSpec<Void> unfinalParams0 = parser.accepts("unfinal-params", "Remove final flag from parameters");
         OptionSpec<Void> fixRecordsO = parser.accepts("record-fix", "Fixes record components and attributes stripped by Proguard.");
         OptionSpec<IdentifierFixerConfig> fixIdsO = parser.accepts("ids-fix", "Fixes local variables that are not valid java identifiers.").withOptionalArg().withValuesConvertedBy(new EnumConverter<>(IdentifierFixerConfig.class)).defaultsTo(IdentifierFixerConfig.ALL);
         OptionSpec<SourceFixerConfig> fixSrcO = parser.accepts("src-fix", "Fixes the 'SourceFile' attribute of classes.").withOptionalArg().withValuesConvertedBy(new EnumConverter<>(SourceFixerConfig.class)).defaultsTo(SourceFixerConfig.JAVA);
@@ -116,6 +117,13 @@ public class Main {
             builder.add(Transformer.parameterAnnotationFixerFactory());
         } else {
             log.accept("Fix Annotations: false");
+        }
+
+        if (options.has(unfinalParams0)) {
+            log.accept("Unfinal Parameters: true");
+            builder.add(Transformer.parameterFinalFlagRemoverFactory());
+        } else {
+            log.accept("Unfinal Parameters: false");
         }
 
         if (options.has(fixRecordsO)) {

--- a/src/main/java/net/neoforged/art/api/Transformer.java
+++ b/src/main/java/net/neoforged/art/api/Transformer.java
@@ -14,6 +14,7 @@ import net.neoforged.art.internal.EntryImpl;
 import net.neoforged.art.internal.FFLineFixer;
 import net.neoforged.art.internal.IdentifierFixer;
 import net.neoforged.art.internal.ParameterAnnotationFixer;
+import net.neoforged.art.internal.ParameterFinalFlagRemover;
 import net.neoforged.art.internal.RecordFixer;
 import net.neoforged.art.internal.RenamingTransformer;
 import net.neoforged.art.internal.SignatureStripperTransformer;
@@ -103,6 +104,13 @@ public interface Transformer {
      */
     public static Factory parameterAnnotationFixerFactory() {
         return ctx -> ParameterAnnotationFixer.INSTANCE;
+    }
+
+    /**
+     * Create a transformer that removes the final attribute from parameter metadata.
+     */
+    public static Factory parameterFinalFlagRemoverFactory() {
+        return ctx -> ParameterFinalFlagRemover.INSTANCE;
     }
 
     /**

--- a/src/main/java/net/neoforged/art/internal/ParameterFinalFlagRemover.java
+++ b/src/main/java/net/neoforged/art/internal/ParameterFinalFlagRemover.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.art.internal;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public final class ParameterFinalFlagRemover extends OptionalChangeTransformer {
+    public static final ParameterFinalFlagRemover INSTANCE = new ParameterFinalFlagRemover();
+
+    private ParameterFinalFlagRemover() {
+        super(Fixer::new);
+    }
+
+    private static class Fixer extends ClassFixer {
+        public Fixer(ClassVisitor parent) {
+            super(parent);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            MethodVisitor methodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+
+            return new MethodFixer(methodVisitor);
+        }
+
+        private class MethodFixer extends MethodVisitor {
+            MethodFixer(MethodVisitor methodVisitor) {
+                super(RenamerImpl.MAX_ASM_VERSION, methodVisitor);
+            }
+
+            @Override
+            public void visitParameter(String name, int access) {
+                if ((access & Opcodes.ACC_FINAL) != 0) {
+                    madeChange = true;
+                    super.visitParameter(name, access & ~Opcodes.ACC_FINAL);
+                } else {
+                    super.visitParameter(name, access);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Mojang now publishes parameter metadata, which retains the `final` attribute they use in their source.

This will cause conflicts in our patches and we will have to patch method signature sources to change the value of parameters inside of method bodies. Because of that, this adds a new option to strip the `final` attribute from parameters.