### PR TITLE
Use updated dependencies that are present on central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ ext {
 
 repositories {
     mavenCentral()
+    maven { url = 'https://maven.neoforged.net/releases' }
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ ext {
 
 repositories {
     mavenCentral()
-    maven { url = 'https://maven.neoforged.net/releases' }
 }
 
 test {
@@ -63,11 +62,11 @@ license {
 dependencies {
     implementation 'net.sf.jopt-simple:jopt-simple:6.0-alpha-3'
     api 'net.neoforged:srgutils:1.0.0'
-    api 'net.neoforged.installertools:cli-utils:2.1.2'
+    api 'net.neoforged.installertools:cli-utils:2.1.3'
     implementation 'org.ow2.asm:asm:9.5'
     implementation 'org.ow2.asm:asm-commons:9.5'
     implementation 'org.ow2.asm:asm-tree:9.5'
-    implementation 'net.neoforged.javadoctor:gson-io:2.0.0'
+    implementation 'net.neoforged.javadoctor:gson-io:2.0.17'
 
     testImplementation(platform('org.junit:junit-bom:5.8.1'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ license {
 dependencies {
     implementation 'net.sf.jopt-simple:jopt-simple:6.0-alpha-3'
     api 'net.neoforged:srgutils:1.0.0'
-    api 'net.neoforged.installertools:cli-utils:2.1.3'
+    api 'net.neoforged.installertools:cli-utils:2.1.4'
     implementation 'org.ow2.asm:asm:9.5'
     implementation 'org.ow2.asm:asm-commons:9.5'
     implementation 'org.ow2.asm:asm-tree:9.5'


### PR DESCRIPTION
Requires neoforged/InstallerTools#3 to actually publish InstallerTools to central; as ART is published to central, all its dependencies should be too.