### PR TITLE
Add descriptor for field scheme inside ClassInfo

### DIFF
--- a/src/main/java/net/neoforged/art/api/ClassProvider.java
+++ b/src/main/java/net/neoforged/art/api/ClassProvider.java
@@ -166,8 +166,20 @@ public interface ClassProvider extends Closeable {
          *
          * @param name the field name
          * @return the field, or an empty optional if it doesn't exist
+         * @deprecated Use with descriptor
+         * @see ClassProvider#getField(String, String)
          */
-        Optional<? extends IFieldInfo> getField(String name); //TODO: Desc?
+        @Deprecated
+        Optional<? extends IFieldInfo> getField(String name);
+
+        /**
+         * Queries a field based on its field name and descriptor.
+         *
+         * @param name the field name
+         * @param desc the field descriptor
+         * @return the field, or an empty optional if it doesn't exist
+         */
+        Optional<? extends IFieldInfo> getField(String name, String desc);
 
         /**
          * Returns all the methods declared in this class.

--- a/src/main/java/net/neoforged/art/internal/ClassProviderImpl.java
+++ b/src/main/java/net/neoforged/art/internal/ClassProviderImpl.java
@@ -119,7 +119,7 @@ class ClassProviderImpl implements ClassProvider {
 
             if (!node.fields.isEmpty())
                 this.fields = Collections.unmodifiableMap(node.fields.stream().map(FieldInfo::new)
-                    .collect(Collectors.toMap(FieldInfo::getName, Function.identity())));
+                    .collect(Collectors.toMap(f -> f.getName() + f.getDescriptor(), Function.identity())));
             else
                 this.fields = null;
         }
@@ -179,9 +179,25 @@ class ClassProviderImpl implements ClassProvider {
             return fieldsView;
         }
 
+        @Deprecated
         @Override
         public Optional<? extends IFieldInfo> getField(String name) {
-            return fields == null ? Optional.empty() : Optional.ofNullable(this.fields.get(name));
+            if (this.fields != null) {
+                for (Map.Entry<String, FieldInfo> entry : this.fields.entrySet()) {
+                    if (entry.getKey().split(" ")[0].equals(name)) {
+                        // Backwards compatibility not possible when duplication
+                        // on field names, constructor was crashing without descriptor logic
+                        // Let it be any in this case
+                        return Optional.of(entry.getValue());
+                    }
+                }
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<? extends IFieldInfo> getField(String name, String desc) {
+            return this.fields == null ? Optional.empty() : Optional.ofNullable(this.fields.get(name + " " + desc));
         }
 
         @Override


### PR DESCRIPTION
Byte-code allow you to have same field names if descriptors are different. Remapper wes crashing if so happened.

File for testing: [ObfProblem-1.0-SNAPSHOT.zip](https://github.com/neoforged/AutoRenamingTool/files/15277881/ObfProblem-1.0-SNAPSHOT.zip)

```
Caused by: java.lang.IllegalStateException: Duplicate key a (attempted merging values private final org/example/obfproblem/ObfProblem/a I and private final org/example/obfproblem/ObfProblem/a Ljava/lang/String;)
        at java.base/java.util.stream.Collectors.duplicateKeyException(Collectors.java:135)
        at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:182)
        at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
        at net.neoforged.art.internal.ClassProviderImpl$ClassInfo.<init>(ClassProviderImpl.java:122)
```