### PR TITLE
Fixed missed separator for methods in ClassInfo scheme

### DIFF
--- a/src/main/java/net/neoforged/art/internal/ClassProviderImpl.java
+++ b/src/main/java/net/neoforged/art/internal/ClassProviderImpl.java
@@ -112,7 +112,7 @@ class ClassProviderImpl implements ClassProvider {
 
             if (!node.methods.isEmpty())
                 this.methods = Collections.unmodifiableMap(node.methods.stream().map(MethodInfo::new)
-                    .collect(Collectors.toMap(m -> m.getName() + m.getDescriptor(), Function.identity())));
+                    .collect(Collectors.toMap(m -> m.getName() + " " + m.getDescriptor(), Function.identity())));
             else
                 this.methods = null;
 
@@ -133,7 +133,7 @@ class ClassProviderImpl implements ClassProvider {
             Map<String, MethodInfo> mtds = Stream.concat(
                 Arrays.stream(node.getConstructors()).map(MethodInfo::new),
                 Arrays.stream(node.getDeclaredMethods()).map(MethodInfo::new)
-            ).collect(Collectors.toMap(m -> m.getName() + m.getDescriptor(), Function.identity()));
+            ).collect(Collectors.toMap(m -> m.getName() + " " + m.getDescriptor(), Function.identity()));
 
             this.methods = mtds.isEmpty() ? null : Collections.unmodifiableMap(mtds);
 


### PR DESCRIPTION
Seems like it should have space.. ( line 196, https://github.com/neoforged/AutoRenamingTool/pull/10/files#diff-72aec42ef36877bb3fec9eae62ec07fe36fc7aff381fbc1e498e8692e0f01ae6R196 )
