### PR TITLE
Reduce ART logger verbosity

### DIFF
--- a/src/main/java/net/neoforged/art/internal/RenamerBuilder.java
+++ b/src/main/java/net/neoforged/art/internal/RenamerBuilder.java
@@ -99,7 +99,7 @@ public class RenamerBuilder implements Builder {
         if (this.withJvmClasspath)
             classProviders.add(ClassProvider.fromJvmClasspath());
 
-        SortedClassProvider sortedClassProvider = new SortedClassProvider(classProviders, this.logger);
+        SortedClassProvider sortedClassProvider = new SortedClassProvider(classProviders, this.debug);
         final Transformer.Context ctx = new Transformer.Context() {
             @Override
             public Consumer<String> getLog() {

--- a/src/main/java/net/neoforged/art/internal/RenamerImpl.java
+++ b/src/main/java/net/neoforged/art/internal/RenamerImpl.java
@@ -159,7 +159,7 @@ class RenamerImpl implements Renamer {
             classProviders.add(0, inputClassesBuilder.build());
 
             // Process everything
-            logger.accept("Processing entries");
+            logger.accept("Processing " + oldEntries.size() + " entries");
             List<Entry> newEntries = async.invokeAll(oldEntries, Entry::getName, this::processEntry);
 
             logger.accept("Adding extras");
@@ -185,7 +185,7 @@ class RenamerImpl implements Renamer {
             PROGRESS.setMaxProgress(newEntries.size());
             PROGRESS.setStep("Writing output");
 
-            logger.accept("Writing Output: " + output.getAbsolutePath());
+            logger.accept("Writing " + newEntries.size() + " to output " + output.getAbsolutePath());
             try (OutputStream fos = new BufferedOutputStream(Files.newOutputStream(output.toPath()));
                  ZipOutputStream zos = new ZipOutputStream(fos)) {
 
@@ -196,7 +196,7 @@ class RenamerImpl implements Renamer {
                     if (idx != -1)
                         addDirectory(zos, seen, name.substring(0, idx));
 
-                    logger.accept("  " + name);
+                    debug.accept("  " + name);
                     ZipEntry entry = new ZipEntry(name);
                     entry.setTime(e.getTime());
                     zos.putNextEntry(entry);
@@ -240,7 +240,7 @@ class RenamerImpl implements Renamer {
         if (idx != -1)
             addDirectory(zos, seen, path.substring(0, idx));
 
-        logger.accept("  " + path + '/');
+        debug.accept("  " + path + '/');
         ZipEntry dir = new ZipEntry(path + '/');
         dir.setTime(Entry.STABLE_TIMESTAMP);
         zos.putNextEntry(dir);

--- a/src/main/java/net/neoforged/art/internal/SortedClassProvider.java
+++ b/src/main/java/net/neoforged/art/internal/SortedClassProvider.java
@@ -16,12 +16,12 @@ import java.util.function.Consumer;
 
 class SortedClassProvider implements ClassProvider {
     List<ClassProvider> classProviders;
-    private final Consumer<String> log;
+    private final Consumer<String> debug;
     private final Map<String, Optional<? extends IClassInfo>> classCache = new ConcurrentHashMap<>();
 
-    SortedClassProvider(List<ClassProvider> classProviders, Consumer<String> log) {
+    SortedClassProvider(List<ClassProvider> classProviders, Consumer<String> debug) {
         this.classProviders = classProviders;
-        this.log = log;
+        this.debug = debug;
     }
 
     @Override
@@ -37,7 +37,7 @@ class SortedClassProvider implements ClassProvider {
                 return classInfo;
         }
 
-        this.log.accept("Can't Find Class: " + name);
+        this.debug.accept("Can't Find Class: " + name);
 
         return Optional.empty();
     }


### PR DESCRIPTION
ART currently prints a lot of info on the console, which happens to be every install:

- The path of every single file in the Minecraft jar
- The name of any library class it encounters (since we don't pass it the library jars)

This PR reduces those two to debug output.