### PR TITLE
Fix remapping annotation attribute names for classes in named packages

### DIFF
--- a/src/main/java/net/neoforged/art/internal/EnhancedRemapper.java
+++ b/src/main/java/net/neoforged/art/internal/EnhancedRemapper.java
@@ -116,7 +116,7 @@ class EnhancedRemapper extends Remapper {
 
     @Override
     public String mapAnnotationAttributeName(String descriptor, String name) {
-        return findMethod(Type.getType(descriptor).getClassName(), name, 0)
+        return findMethod(Type.getType(descriptor).getInternalName(), name, 0)
                 .map(MClass.MMethod::getMapped)
                 .orElse(name);
     }


### PR DESCRIPTION
PR #13 introduced code intended to support mapping annotation attribute names by updating `EnhancedRemapper#mapAnnotationAttributeName(String, String)`, but a bug in the code currently causes any annotations whose unmapped class name is in a named package (i.e., any package that isn't the unnamed package) to have their attribute names fail to map. This PR fixes that bug.

As stated in the description of #13, the change was made due to the introduction of annotation `net.minecraft.SuppressForbidden` in 24w45a. This is the first time that Mojang has included an annotation in the Minecraft codebase with an attribute AND at the same time used that annotation with its attribute being set elsewhere in the code. The code prior to #13 did not remap annotation attribute names at all, so compilation errors were found during work with 24w45a (see context [here](https://discord.com/channels/313125603924639766/1298372610962358323/1303750487924801596)).

The solution merged from #13 works for the purposes of remapping the obfuscated Minecraft jar to Mojang mappings, which is likely why the bug was not caught until now. The crux of the bug is in [this line](https://github.com/neoforged/AutoRenamingTool/blob/003fcc25c2ed24e590ad34518a7cfb8a57216521/src/main/java/net/neoforged/art/internal/EnhancedRemapper.java#L119). `org.objectweb.asm.Type#getClassName()` returns the class name with packages delimited by periods (`.`), while `Type#getInternalName()` returns the class name with packages delimited by forward slashes (`/`). This line uses `Type#getClassName()` to call `EnhancedRemapper#findMethod()`.

However, `findMethod()` expects the `owner` parameter with the relevant class name to be delimited by forward slashes (`/`). One can see this by looking at usages of the helper method `getClass()`, which looks up the class given the `owner` parameter. One usage of `getClass()` can be seen [here](https://github.com/neoforged/AutoRenamingTool/blob/003fcc25c2ed24e590ad34518a7cfb8a57216521/src/main/java/net/neoforged/art/internal/EnhancedRemapper.java#L86-L88), which, when consulting the documentation for [org.objectweb.asm.commons.Remapper#map(String)](https://asm.ow2.io/javadoc/org/objectweb/asm/commons/Remapper.html#map(java.lang.String)), explains that it "maps the _internal_ name of a class to its new name."

Thus, a simple mistake was made during the creation of #13. The reason this has not affected remapping the obfuscated Minecraft jar is because the obfuscated jar uses the unnamed package for all obfuscated classes. In 1.21.8, `net.minecraft.SuppressForbidden` has an obfuscated name of `ad`. When `mapAnnotationAttributeName()` is called during renaming of the obfuscated Minecraft jar, the provided descriptor is then `Lad;`, which does not have a package in its class name. Thus, `Type#getClassName()` and `Type#getInternalName()` produce the exact same string for this descriptor of `"ad"`. So, the lookup still succeeds in this specific case, but fails whenever the unmapped annotation descriptor references a class NOT in the unnamed package (i.e., a class within at least one package), as then the produced `owner` string contains periods when it _should_ contain forward slashes to delimit the packages.

The fix is simple enough, just swap the incorrect `getClassName()` method for the correct `getInternalName()` method, which makes ART more robust for more general remapping purposes (which is how I discovered the bug in the first place).

Full rationale first mentioned in Discord here originally: https://discord.com/channels/313125603924639766/570666026077913098/1405469811584270480